### PR TITLE
fix: comment decomposition issue fixed

### DIFF
--- a/kaizen/helpers/output.py
+++ b/kaizen/helpers/output.py
@@ -85,7 +85,7 @@ def get_web_html(url):
     
     # Delete each comment
     for comment in soup.find_all(text=lambda text: isinstance(text, Comment)):
-        comment.decompose()
+        comment.extract()
     
     for style_block in soup.find_all('style'):
         style_block.decompose()


### PR DESCRIPTION
## PR Description
This pull request aims to fix the comment decomposition issue in the `output.py` file within the `kaizen/helpers` directory.

### Changes
- The code modification involves replacing the `comment.decompose()` method with `comment.extract()` to address the comment decomposition issue.

### Motivation
The motivation behind these changes is to resolve the issue where the `comment.decompose()` method was not functioning as expected, leading to incomplete comment removal. By using `comment.extract()`, the code aims to ensure proper and complete removal of comments, enhancing the overall functionality and maintainability of the codebase.

 -- Generated with love by Kaizen


<details>
<summary>Original Description</summary>
None
</details>
