### PR TITLE
104 add alternative setup to configjson

### DIFF
--- a/kaizen/helpers/output.py
+++ b/kaizen/helpers/output.py
@@ -6,7 +6,7 @@ import nest_asyncio
 import subprocess
 import os
 import json
-import general
+from kaizen.helpers import general
 
 logger = logging.getLogger(__name__)
 

--- a/kaizen/utils/config.py
+++ b/kaizen/utils/config.py
@@ -1,10 +1,27 @@
 import json
 import os
+from pathlib import Path
 
 
 def get_config():
-    with open("config.json", "r") as f:
-        config_data = json.loads(f.read())
+    # Get the directory of the calling function
+    caller_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+    config_file = f"{caller_dir}/config.json"
+    if Path(config_file).is_file():
+        with open(config_file, "r") as f:
+            config_data = json.loads(f.read())
+    else:
+        config_data = {
+            "language_model": {
+                "provider": "litellm",
+                "enable_observability_logging": False
+            },
+            "github_app": {
+                "check_signature": False,
+                "auto_pr_review": False,
+                "edit_pr_desc": False
+            }
+        }
     return config_data
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -708,6 +708,20 @@ ssh = ["paramiko"]
 tqdm = ["tqdm"]
 
 [[package]]
+name = "fuzzywuzzy"
+version = "0.18.0"
+description = "Fuzzy string matching in python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "fuzzywuzzy-0.18.0-py2.py3-none-any.whl", hash = "sha256:928244b28db720d1e0ee7587acf660ea49d7e4c632569cad4f1cd7e68a5f0993"},
+    {file = "fuzzywuzzy-0.18.0.tar.gz", hash = "sha256:45016e92264780e58972dca1b3d939ac864b78437422beecebb3095f8efd00e8"},
+]
+
+[package.extras]
+speedup = ["python-levenshtein (>=0.12)"]
+
+[[package]]
 name = "greenlet"
 version = "3.0.3"
 description = "Lightweight in-process concurrent programming"
@@ -1550,7 +1564,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2113,4 +2126,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "a3543fc32823ee5e71aa6377d3063debeb87c6fd395222e35d3627ab4840212a"
+content-hash = "2953dc06affb1257cbb24221a538d4bc33164f029077927dfae1b200bf050eb2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cloudcode"
-version = "0.1.1"
+version = "0.1.2"
 description = "An intelligent coding companion that accelerates your development workflow by providing efficient assistance, enabling you to craft high-quality code more rapidly."
 authors = ["Saurav Panda <saurav.panda@cloudcode.ai>"]
 license = "Apache2.0"
@@ -23,6 +23,7 @@ bs4 = "^0.0.2"
 nest-asyncio = "^1.6.0"
 pytest-playwright = "^0.4.4"
 pip = "^24.0"
+fuzzywuzzy = "^0.18.0"
 
 
 [build-system]

--- a/tests/actions/test_review.py
+++ b/tests/actions/test_review.py
@@ -1,6 +1,6 @@
 import pytest
 import json
-from kaizen.actions.reviews import CodeReviewer
+from kaizen.reviewer.code_review import CodeReviewer
 from fuzzywuzzy import fuzz
 
 with open("tests/data/actions/valid_review.json") as f:


### PR DESCRIPTION
## Pull Request Description
This pull request introduces changes aimed at adding an alternative setup to the `config.json` file and updating dependencies.

### Changes
1. In `output.py`, the import statement was modified to use `kaizen.helpers` instead of `general`.
2. In `config.py`, the `get_config` function was updated to dynamically locate the `config.json` file and provide default values if the file is not found.
3. Dependencies in `poetry.lock` and `pyproject.toml` were updated, including the addition of the `fuzzywuzzy` package.

### Motivation
The changes aim to improve the flexibility and robustness of the configuration setup by allowing an alternative location for the `config.json` file. Additionally, updating dependencies ensures compatibility and potentially introduces new functionality through the `fuzzywuzzy` package.


 -- Generated with love by Kaizen


<details>
<summary>Original Description</summary>
None
</details>
