### PR TITLE
bugfix: keyname not found in patch

### DIFF
--- a/kaizen/reviewer/code_review.py
+++ b/kaizen/reviewer/code_review.py
@@ -59,9 +59,9 @@ class CodeReviewer:
             # We recurrsively get feedback for files and then get basic summary
             reviews = []
             for file in pull_request_files:
-                patch_details = file["patch"]
-                filename = file["filename"]
-                if filename.split(".")[-1] not in parser.EXCLUDED_FILETYPES:
+                patch_details = file.get("patch")
+                filename = file.get("filename", "")
+                if filename.split(".")[-1] not in parser.EXCLUDED_FILETYPES and patch_details is not None:
                     prompt = FILE_CODE_REVIEW_PROMPT.format(
                         PULL_REQUEST_TITLE=pull_request_title,
                         PULL_REQUEST_DESC=pull_request_desc,


### PR DESCRIPTION
## Pull Request Description
This pull request aims to address a bug related to the 'keyname not found in patch' issue in the code_review.py file within the kaizen/reviewer module.

### Changes
- Refactored the code to handle potential None values for 'patch' and 'filename' attributes to prevent potential KeyError.
- Added a conditional check for 'patch_details' to ensure it's not None before processing.

The changes focus on improving error handling and preventing potential issues related to missing 'patch' or 'filename' attributes, ultimately enhancing the reliability and robustness of the code.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>
