### PR TITLE
fix: added a kaizen docs

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -4,8 +4,8 @@ const withNextra = require('nextra')({
   })
    
   module.exports = withNextra({
-    basePath: process.env.NEXT_PUBLIC_BASE_PATH,
-    assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH,
+    basePath: '/kaizen/docs/',
+    assetPrefix: '/kaizen/docs/',
     images: {
       unoptimized: true
     },


### PR DESCRIPTION
### Summary

Fixes in the `next.config.js` file to add a kaizen docs.

### Details

- Modified `basePath` and `assetPrefix` in the `next.config.js` file to '/kaizen/docs/'.
- Updated the `basePath` and `assetPrefix` values to fix the location of the kaizen docs.
- Images now have the `unoptimized` flag set to true in the `images` configuration.
  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

