### PR TITLE
update cli publishing

### DIFF
--- a/.github/workflows/ pypi-publish-cli.yml
+++ b/.github/workflows/ pypi-publish-cli.yml
@@ -25,5 +25,5 @@ jobs:
         run: |
           poetry install --with prod --no-dev
           poetry build
-          poetry publish --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
+          poetry publish --username __token__ --password ${{ secrets.PYPI_API_TOKEN_CLI }}
         working-directory: ./cli


### PR DESCRIPTION
### Summary
Update CLI publishing workflow to use a new PyPI API token for authentication.

### Details
- Updated the PyPI publishing workflow in the '.github/workflows/pypi-publish-cli.yml' file to use a new PyPI API token for CLI publishing.
- Changed the value of the '--password' argument in the 'poetry publish' command to reference the updated API token variable.
  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

