### PR TITLE
feat: Added try error block for kaizen cli

### DIFF
--- a/cli/kaizen_cli/cli.py
+++ b/cli/kaizen_cli/cli.py
@@ -17,10 +17,15 @@ def load_config():
                 user_config = json.load(f)
             config.update(user_config)  # Override defaults with user config
         except json.JSONDecodeError:
-            click.echo(f"Warning: Config file {CONFIG_FILE} is not valid JSON. Using default configuration.")
+            click.echo(
+                f"Warning: Config file {CONFIG_FILE} is not valid JSON. Using default configuration."
+            )
         except IOError as e:
-            click.echo(f"Warning: Unable to read config file {CONFIG_FILE}. Using default configuration. Error: {e}")
+            click.echo(
+                f"Warning: Unable to read config file {CONFIG_FILE}. Using default configuration. Error: {e}"
+            )
     return config
+
 
 def save_config(config):
     try:
@@ -28,7 +33,6 @@ def save_config(config):
             json.dump(config, f, indent=2)
     except IOError as e:
         click.echo(f"Error: Unable to save config file {CONFIG_FILE}. Error: {e}")
-
 
 
 @click.group()

--- a/cli/kaizen_cli/cli.py
+++ b/cli/kaizen_cli/cli.py
@@ -12,15 +12,23 @@ DEFAULT_CONFIG = {"region": "us-east-1", "output": "json", "timeout": 60}
 def load_config():
     config = DEFAULT_CONFIG.copy()  # Start with default config
     if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, "r") as f:
-            user_config = json.load(f)
-        config.update(user_config)  # Override defaults with user config
+        try:
+            with open(CONFIG_FILE, "r") as f:
+                user_config = json.load(f)
+            config.update(user_config)  # Override defaults with user config
+        except json.JSONDecodeError:
+            click.echo(f"Warning: Config file {CONFIG_FILE} is not valid JSON. Using default configuration.")
+        except IOError as e:
+            click.echo(f"Warning: Unable to read config file {CONFIG_FILE}. Using default configuration. Error: {e}")
     return config
 
-
 def save_config(config):
-    with open(CONFIG_FILE, "w") as f:
-        json.dump(config, f, indent=2)
+    try:
+        with open(CONFIG_FILE, "w") as f:
+            json.dump(config, f, indent=2)
+    except IOError as e:
+        click.echo(f"Error: Unable to save config file {CONFIG_FILE}. Error: {e}")
+
 
 
 @click.group()

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Saurav Panda <sgp65@cornell.edu>"]
 readme = "README.md"


### PR DESCRIPTION
### Summary
Added try-except blocks for error handling in kaizen CLI.

### Details
- Added try-except blocks in `load_config()` function to handle `JSONDecodeError` and `IOError` when reading the config file.
- Added try-except block in `save_config()` function to handle `IOError` when saving the config file.
- Updated version to 0.1.2 in pyproject.toml file
  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

