### PR TITLE
made reeval of prompts optional

### DIFF
--- a/kaizen/reviewer/code_review.py
+++ b/kaizen/reviewer/code_review.py
@@ -57,6 +57,7 @@ class CodeReviewer:
         pull_request_desc: str,
         pull_request_files: List[Dict],
         user: Optional[str] = None,
+        reeval_response: Optional[bool] = False
     ) -> ReviewOutput:
 
         # If diff_text is smaller than 70% of model token
@@ -70,16 +71,17 @@ class CodeReviewer:
             self.logger.debug("Processing Directly from Diff")
             resp, usage = self.provider.chat_completion(prompt, user=user)
             total_usage = self.provider.update_usage(total_usage, usage)
-            # Review the response
-            messages = [
-                {"role": "system", "content": self.provider.system_prompt},
-                {"role": "user", "content": prompt},
-                {"role": "assistant", "content": resp},
-                {"role": "user", "content": PR_REVIEW_EVALUATION_PROMPT},
-            ]
-            resp, usage = self.provider.chat_completion(
-                prompt, user=user, messages=messages
-            )
+            if reeval_response:
+                # Review the response
+                messages = [
+                    {"role": "system", "content": self.provider.system_prompt},
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": resp},
+                    {"role": "user", "content": PR_REVIEW_EVALUATION_PROMPT},
+                ]
+                resp, usage = self.provider.chat_completion(
+                    prompt, user=user, messages=messages
+                )
             review_json = parser.extract_json(resp)
             reviews = review_json["review"]
             total_usage = self.provider.update_usage(total_usage, usage)
@@ -106,17 +108,17 @@ class CodeReviewer:
                         continue
                     resp, usage = self.provider.chat_completion(prompt, user=user)
                     total_usage = self.provider.update_usage(total_usage, usage)
-                    total_usage = self.provider.update_usage(total_usage, usage)
-                    # Review the response
-                    messages = [
-                        {"role": "system", "content": self.provider.system_prompt},
-                        {"role": "user", "content": prompt},
-                        {"role": "assistant", "content": resp},
-                        {"role": "user", "content": PR_REVIEW_EVALUATION_PROMPT},
-                    ]
-                    resp, usage = self.provider.chat_completion(
-                        prompt, user=user, messages=messages
-                    )
+                    if reeval_response:
+                        # Review the response
+                        messages = [
+                            {"role": "system", "content": self.provider.system_prompt},
+                            {"role": "user", "content": prompt},
+                            {"role": "assistant", "content": resp},
+                            {"role": "user", "content": PR_REVIEW_EVALUATION_PROMPT},
+                        ]
+                        resp, usage = self.provider.chat_completion(
+                            prompt, user=user, messages=messages
+                        )
                     review_json = parser.extract_json(resp)
                     reviews.extend(review_json["review"])
 
@@ -140,6 +142,7 @@ class CodeReviewer:
         pull_request_desc: str,
         pull_request_files: List[Dict],
         user: Optional[str] = None,
+        reeval_response: Optional[bool] = False
     ):
         """
         This method generates a AI powered description for a pull request.
@@ -155,17 +158,18 @@ class CodeReviewer:
             self.logger.debug("Processing Directly from Diff")
             resp, usage = self.provider.chat_completion(prompt, user=user)
             total_usage = self.provider.update_usage(total_usage, usage)
-            # Review the response
-            messages = [
-                {"role": "system", "content": self.provider.system_prompt},
-                {"role": "user", "content": prompt},
-                {"role": "assistant", "content": resp},
-                {"role": "user", "content": PR_DESC_EVALUATION_PROMPT},
-            ]
-            resp, usage = self.provider.chat_completion(
-                prompt, user=user, messages=messages
-            )
-            total_usage = self.provider.update_usage(total_usage, usage)
+            if reeval_response:
+                # Review the response
+                messages = [
+                    {"role": "system", "content": self.provider.system_prompt},
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": resp},
+                    {"role": "user", "content": PR_DESC_EVALUATION_PROMPT},
+                ]
+                resp, usage = self.provider.chat_completion(
+                    prompt, user=user, messages=messages
+                )
+                total_usage = self.provider.update_usage(total_usage, usage)
             desc = parser.extract_json(resp)["desc"]
         else:
             self.logger.debug("Processing Based on files")
@@ -188,17 +192,18 @@ class CodeReviewer:
                         continue
                     resp, usage = self.provider.chat_completion(prompt, user=user)
                     total_usage = self.provider.update_usage(total_usage, usage)
-                    # Review the response
-                    messages = [
-                        {"role": "system", "content": self.provider.system_prompt},
-                        {"role": "user", "content": prompt},
-                        {"role": "assistant", "content": resp},
-                        {"role": "user", "content": PR_DESC_EVALUATION_PROMPT},
-                    ]
-                    resp, usage = self.provider.chat_completion(
-                        prompt, user=user, messages=messages
-                    )
-                    total_usage = self.provider.update_usage(total_usage, usage)
+                    if reeval_response:
+                        # Review the response
+                        messages = [
+                            {"role": "system", "content": self.provider.system_prompt},
+                            {"role": "user", "content": prompt},
+                            {"role": "assistant", "content": resp},
+                            {"role": "user", "content": PR_DESC_EVALUATION_PROMPT},
+                        ]
+                        resp, usage = self.provider.chat_completion(
+                            prompt, user=user, messages=messages
+                        )
+                        total_usage = self.provider.update_usage(total_usage, usage)
                     desc_json = parser.extract_json(resp)
                     descs.append(desc_json["desc"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cloudcode"
-version = "0.2.12"
+version = "0.2.13"
 description = "An intelligent coding companion that accelerates your development workflow by providing efficient assistance, enabling you to craft high-quality code more rapidly."
 authors = ["Saurav Panda <saurav.panda@cloudcode.ai>"]
 license = "Apache2.0"


### PR DESCRIPTION
### Summary

Updated code review methods to optionally re-evaluate prompts for more efficient processing and reduced resource usage.

### Details

#### Key Changes

- Added an optional `reeval_response` parameter to the `review_pull_request` and `generate_pull_request_desc` methods to enable/disable re-evaluation of prompts.

#### New Features

- None

#### Refactoring Details

- Enhanced the `review_pull_request` and `generate_pull_request_desc` methods to include a more flexible approach to handling evaluation prompts through the new `reeval_response` parameter.
- The `reeval_response` parameter is used to control whether the response from the AI model should be re-evaluated using another prompt.

#### Other Significant Aspects

- The modification of the existing methods improves the performance of the code by allowing users to opt-out of the re-evaluation process if it's not needed, saving computational resources.
- The new parameter is set to `Optional[bool]` with a default value of `False`, ensuring that the existing behavior remains unchanged unless explicitly set by the user.

#### Potential Improvements

- Clear documentation and comments may be necessary to explain the purpose of the new parameter and how it affects the behavior of the methods.
- Tests should be updated to cover cases where the `reeval_response` parameter is set to both `True` and `False`. This ensures that the changes in behavior are properly tested and do not introduce any unintended side effects.
- Consider renaming the new parameter to `should_reevaluate_response` to better reflect its purpose and improve readability.
  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

