### PR TITLE
fix: Added work summary usage in response for social media posts

### DIFF
--- a/examples/work_summarizer/main.py
+++ b/examples/work_summarizer/main.py
@@ -56,8 +56,8 @@ work_summary_generator = WorkSummaryGenerator()
 result = work_summary_generator.generate_work_summaries(file_diffs, user="oss_example")
 summary = result["summary"]
 
-twitter_post = work_summary_generator.generate_twitter_post(summary, user="oss_example")
-linkedin_post = work_summary_generator.generate_linkedin_post(
+twitter_post, _ = work_summary_generator.generate_twitter_post(summary, user="oss_example")
+linkedin_post, _ = work_summary_generator.generate_linkedin_post(
     summary, user="oss_example"
 )
 

--- a/kaizen/reviewer/work_summarizer.py
+++ b/kaizen/reviewer/work_summarizer.py
@@ -61,8 +61,8 @@ class WorkSummaryGenerator:
         user: Optional[str] = None,
     ) -> str:
         prompt = TWITTER_POST_PROMPT.format(SUMMARY=summary)
-        response, _ = self.provider.chat_completion(prompt, user=user)
-        return parser.extract_markdown_content(response)
+        response, total_usage = self.provider.chat_completion(prompt, user=user)
+        return parser.extract_markdown_content(response), total_usage
 
     def generate_linkedin_post(
         self,
@@ -70,5 +70,5 @@ class WorkSummaryGenerator:
         user: Optional[str] = None,
     ) -> str:
         prompt = LINKEDIN_POST_PROMPT.format(SUMMARY=summary)
-        response, _ = self.provider.chat_completion(prompt, user=user)
-        return parser.extract_markdown_content(response)
+        response, total_usage = self.provider.chat_completion(prompt, user=user)
+        return parser.extract_markdown_content(response), total_usage


### PR DESCRIPTION
### Summary

Implemented work summary usage in response for social media posts

### Details

- Added the `total_usage` parameter in the `generate_twitter_post` and `generate_linkedin_post` methods of the `WorkSummarizer` class.
- Modified the main.py file to capture the `total_usage` returned from the newly updated methods.
- The social media post generation methods now return both the generated post content (markdown) and the `total_usage`.


> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

