### PR TITLE
262 update ci cd flow to build docs at cloudcode ai domain

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,4 +1,4 @@
-name: Update Docs on GitHub Pages
+name: Update Docs on GitHub Pages and S3
 
 on:
   push:
@@ -49,4 +49,6 @@ jobs:
         
       - name: Copy files to specific path
         run: |          
-          cp -R docs/out/* ${{ secrets.S3_BUCKET_PATH }}/
+          aws s3 cp docs/out ${{ secrets.S3_BUCKET_PATH }}/ --recursive
+
+


### PR DESCRIPTION
### Summary

Update CI/CD flow to build docs on GitHub Pages and S3.

### Details

- The CI/CD pipeline has been updated to build documentation on GitHub Pages and upload it to S3.
- The workflow's name has been updated from *Update Docs on GitHub Pages* to *Update Docs on GitHub Pages and S3*.
- The AWS CLI command to copy files to the S3 bucket, `aws s3 cp docs/out ${{secrets.S3_BUCKET_PATH}}/ --recursive`, has been added to the *Copy files to specific path* job.
- Previously, the `cp -R docs/out/* ${{secrets.S3_BUCKET_PATH}}/` command was used to copy files, which is not as efficient or effective for working with S3 as the new `aws s3 cp` command.
- The changes do not provide a pull request description, but from the diff we can deduce that the intention is to update the CI/CD process to build documentation that is then pushed to GitHub Pages and Amazon S3.
- It is important to note that the original `cp` command has been replaced, and the diff does not indicate any further significant changes outside of this replacement.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

