### PR TITLE
262 update ci cd flow to build docs at cloudcode ai domain

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -4,12 +4,13 @@ const withNextra = require('nextra')({
   })
    
   module.exports = withNextra({
-    basePath: process.env.NEXT_PUBLIC_BASE_PATH,
-    assetPrefix: process.env.NEXT_PUBLIC_BASE_PATH,
+    basePath: "/kaizen/docs",
+    assetPrefix: "/kaizen/docs",
     images: {
       unoptimized: true
     },
-    output: 'export'
+    output: 'export',
+
 })
    
   // If you have other Next.js configurations, you can pass them as the parameter:


### PR DESCRIPTION
### Summary

Update CI/CD flow to build docs at the `/kaizen/docs` domain.

### Details

- **Key Changes:**
  - The `basePath` and `assetPrefix` properties in `next.config.js` have been updated to use the `/kaizen/docs` domain.
  - A trailing comma has been added after the `output` property in the configuration file.
- **Refactoring Details:**
  - The `basePath` and `assetPrefix` properties were previously set using environment variables `process.env.NEXT_PUBLIC_BASE_PATH`. These have now been replaced with a direct string value `/kaizen/docs`.
  - It appears that the environment variables `process.env.NEXT_PUBLIC_BASE_PATH` are no longer being used for the `basePath` and `assetPrefix` properties.
- **Additional Considerations:**
  - This pull request does not include a detailed description, so the full context of the changes is not fully provided.
  - Assuming the objective is to update the docs build process to deploy to the `/kaizen/docs` domain, this PR accomplishes that goal.
  - Adding a description to the pull request could help clarify the changes and provide more context.
  

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

