### PR TITLE
Include System Prompt in Token Limit Calculation

### DIFF
--- a/kaizen/llms/provider.py
+++ b/kaizen/llms/provider.py
@@ -111,8 +111,11 @@ class LLMProvider:
         return response["choices"][0]["message"]["content"], response["usage"]
 
     def is_inside_token_limit(self, PROMPT: str, percentage: float = 0.8) -> bool:
-        # TODO: Also include system prompt
-        messages = [{"user": "role", "content": PROMPT}]
+        # Include system prompt in token calculation
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": PROMPT}
+        ]
         token_count = litellm.token_counter(model=self.model, messages=messages)
         max_tokens = litellm.get_max_tokens(self.model)
         return token_count <= max_tokens * percentage

--- a/tests/llms/test_provider.py
+++ b/tests/llms/test_provider.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import patch
 from kaizen.llms.provider import LLMProvider
 
-
 @pytest.fixture
 def mock_config_data():
     with patch("kaizen.utils.config.ConfigData") as MockConfigData:
@@ -15,16 +14,13 @@ def mock_config_data():
         }
         yield mock_config
 
-
 @pytest.fixture
 def llm_provider(mock_config_data):
     return LLMProvider()
 
-
 def test_initialization(llm_provider):
     assert llm_provider.model == "gpt-3.5-turbo-1106"
     assert llm_provider.model_config == {"model": "gpt-3.5-turbo-1106"}
-
 
 @patch("kaizen.llms.provider.litellm.completion")
 def test_chat_completion(mock_completion, llm_provider):
@@ -36,16 +32,23 @@ def test_chat_completion(mock_completion, llm_provider):
     assert response is not None
     assert usage is not None
 
-
 @patch("kaizen.llms.provider.litellm.token_counter")
 @patch("kaizen.llms.provider.litellm.get_max_tokens")
 def test_is_inside_token_limit(mock_get_max_tokens, mock_token_counter, llm_provider):
     mock_token_counter.return_value = 100
     mock_get_max_tokens.return_value = 150
+
+    # Including system prompt in the calculation
+    system_prompt_length = len(llm_provider.system_prompt.split())
+    user_prompt_length = len("test prompt".split())
+    total_length = system_prompt_length + user_prompt_length
+
+    mock_token_counter.return_value = total_length
+
     assert llm_provider.is_inside_token_limit("test prompt") is True
+
     mock_token_counter.return_value = 120
     assert llm_provider.is_inside_token_limit("test prompt") is False
-
 
 @patch("kaizen.llms.provider.litellm.token_counter")
 @patch("kaizen.llms.provider.litellm.get_max_tokens")
@@ -54,8 +57,7 @@ def test_available_tokens(mock_get_max_tokens, mock_token_counter, llm_provider)
     mock_get_max_tokens.return_value = 150
     assert llm_provider.available_tokens("test message") == 20
 
-
 @patch("kaizen.llms.provider.litellm.token_counter")
 def test_get_token_count(mock_token_counter, llm_provider):
     mock_token_counter.return_value = 50
-    assert llm_provider.get_token_count("test message")
+    assert llm_provider.get_token_count("test message") == 50


### PR DESCRIPTION
This PR updates the ` LLMProvider ` class to include the system prompt in the token limit calculation, ensuring that the token count accurately reflects the total number of tokens used by both the system and user prompts.

### changes made
- Modified the ` is_inside_token_limit ` method to include the system prompt in the token count.
- Adjusted the logic to calculate the total tokens used by concatenating the system and user prompts.
- Updated the ` test_is_inside_token_limit ` function to mock the token count correctly by considering both the system and user prompts.

fixes issue #271 