### PR TITLE
fix: added way to pass and configure custom models

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,9 +10,7 @@
                     "model": "gpt-3.5-turbo-1106",
                     "input_cost_per_token": 0.0000005,
                     "output_cost_per_token": 0.0000015
-                },
-                "tpm": 100000,
-                "rpm": 1000
+                }
             },
             {
                 "model_name": "best",
@@ -20,9 +18,24 @@
                     "model": "gpt-4o",
                     "input_cost_per_token": 0.000005,
                     "output_cost_per_token": 0.000015
+                }
+            },
+            {
+                "model_name": "CUSTOM_MODEL",
+                "litellm_params": {
+                    "model": "azure_ai/MODEL_NAME",
+                    "api_key": "os.environ/CUSTOM_API_KEY",
+                    "api_base": "os.environ/CUSTOM_API_BASE"
                 },
-                "tpm": 100000,
-                "rpm": 10000
+                "model_info": {
+                    "max_tokens": 4096,
+                    "input_cost_per_token": 0.000015,
+                    "output_cost_per_token": 0.000015,
+                    "max_input_tokens": 128000,
+                    "max_output_tokens": 4096,
+                    "litellm_provider": "openai",
+                    "mode": "chat"
+                }
             }
         ]
     },


### PR DESCRIPTION
### Summary

Implemented a feature to pass and configure custom models.

### Details

- Added a new configuration section for a custom model named 'CUSTOM_MODEL' in the `config.json` file.
- The custom model configuration includes parameters for the model name, LiteLLM parameters like model, API key, and API base, and model info such as max tokens, input and output cost per token, max input and output tokens, LiteLLM provider, and mode.
- Updated the `kaizen/llms/provider.py` file to include a method `_register_unkown_models()`. This method is responsible for registering any unknown models defined in the configuration.
- Modified the `chat_completion()` function to use the custom model if it is provided, and to use the default model otherwise.
- Added a `model` parameter to the `available_tokens()` and `get_token_count()` methods. This allows them to work with custom models.
- Updated the `get_usage_cost()` method to take a `model` parameter, allowing it to calculate the cost based on the specified model.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

