### PR TITLE
fix: tag issue in output markdown

### DIFF
--- a/kaizen/helpers/output.py
+++ b/kaizen/helpers/output.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 PR_COLLAPSIBLE_TEMPLATE = """
 <details>
 <summary> --> {comment}</summary> \n
-</strong> Potential Solution:</strong> \n\n{solution}
+<strong> Potential Solution:</strong> \n\n{solution}
 \n
 <blockquote>  
     <p><code>{file_name} | {start_line} - {end_line}</code></p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cloudcode"
-version = "0.3.7"
+version = "0.3.8"
 description = "An intelligent coding companion that accelerates your development workflow by providing efficient assistance, enabling you to craft high-quality code more rapidly."
 authors = ["Saurav Panda <saurav.panda@cloudcode.ai>"]
 license = "Apache2.0"


### PR DESCRIPTION
### Summary

This pull request fixes an issue with incorrect tag formatting in the output markdown.

### Details

- **Issue:** The `PR_COLLAPSIBLE_TEMPLATE` in `kaizen/helpers/output.py` was incorrectly using a closing tag (`</strong>`) before the opening tag (`<strong>`).
- **Fix:** The closing tag was moved after the opening tag to ensure correct formatting.
- **Version Bump:** The version in `pyproject.toml` was updated to `0.3.8` to reflect the fix.


> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

