### PR TITLE
fix: updated the work summary prompt to merge multiple summaries

### DIFF
--- a/examples/work_summarizer/main.py
+++ b/examples/work_summarizer/main.py
@@ -8,7 +8,7 @@ GITHUB_REPO_NAME = "kaizen"
 
 # Get the current date and calculate the date 14 days ago
 current_date = datetime.now(timezone.utc).date()
-since_date = current_date - timedelta(days=7)
+since_date = current_date - timedelta(days=14)
 
 # Convert the date to ISO format
 since_date_iso = since_date.isoformat()

--- a/kaizen/llms/prompts/work_summary_prompts.py
+++ b/kaizen/llms/prompts/work_summary_prompts.py
@@ -27,7 +27,7 @@ OUTPUT Format:
 }}
 
 estimated_time: its the range of time you think the above work might have taken for a developer. example "10-15hrs"
-details: its list of important changes in human readable term so that anyone can understand how the software has been impacted.
+details: its list of changes in human readable term so that anyone can understand how the software has been impacted.
   
 Guidelines:  
 1. Give a high-level overview of the goal.  
@@ -39,6 +39,26 @@ Guidelines:
 7. Maintain a consistent, readable tone.  
   
 PATCH DATA: {PATCH_DATA}  
+"""
+
+MERGE_WORK_SUMMARY_PROMPT = """  
+Merge all this information into the following output format.
+
+OUTPUT Format:  
+{{
+    "summary": "<SUMMARY_OF_WORK_DONE>",  
+    "details": ["<IMPORTANT_DETAILS>", ...],  
+    "todo": ["<TODO_ITEMS>", ...],  
+    "future_considerations": ["<THINGS_TO_CONSIDER_IN_FUTURE>", ...],  
+    "estimated_time": <ESTIMATED_TIME_IN_HOURS>  
+}}
+
+estimated_time: its the range of time you think the above work might have taken for a developer in hours, be little generous. example "10-15hrs"
+details: its list of changes in human readable term so that anyone can understand how the software has been impacted.
+  
+All the summaries: 
+
+{SUMMARY_JSON}
 """
 
 TWITTER_POST_PROMPT = """

--- a/kaizen/reviewer/work_summarizer.py
+++ b/kaizen/reviewer/work_summarizer.py
@@ -6,8 +6,10 @@ from kaizen.llms.prompts.work_summary_prompts import (
     WORK_SUMMARY_SYSTEM_PROMPT,
     TWITTER_POST_PROMPT,
     LINKEDIN_POST_PROMPT,
+    MERGE_WORK_SUMMARY_PROMPT
 )
 import logging
+import json
 
 
 class WorkSummaryGenerator:
@@ -55,7 +57,9 @@ class WorkSummaryGenerator:
 
         if len(summaries) > 1:
             # TODO Merge summaries
-            pass
+            prompt = MERGE_WORK_SUMMARY_PROMPT.format(SUMMARY_JSON=json.dumps(summaries))
+            response, usage = self.provider.chat_completion_with_json(prompt, user=user)
+            summaries = [response]
 
         return {"summary": summaries[0], "usage": self.total_usage}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cloudcode"
-version = "0.3.9"
+version = "0.3.10"
 description = "An intelligent coding companion that accelerates your development workflow by providing efficient assistance, enabling you to craft high-quality code more rapidly."
 authors = ["Saurav Panda <saurav.panda@cloudcode.ai>"]
 license = "Apache2.0"


### PR DESCRIPTION
### Summary

This pull request updates the work summarizer to merge multiple summaries into a single consolidated summary.

### Details

- **Updated `work_summary_prompts.py`:**
    - Added a new prompt `MERGE_WORK_SUMMARY_PROMPT` to merge multiple work summaries into a single summary.
    - Modified the `details` field in the prompt to be a list of changes instead of a single string.
- **Updated `work_summarizer.py`:**
    - Modified the `generate_work_summaries` function to use the `MERGE_WORK_SUMMARY_PROMPT` when multiple summaries are present.
    - The function now uses `json.dumps` to convert the list of summaries into a JSON string for the prompt.
- **Updated `project.toml`:**
    - Bumped the version to `0.3.10`.


> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

