### PR TITLE
336 change the prompt for pr review based on new pr data passing method

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,9 +7,9 @@
             {
                 "model_name": "default",
                 "litellm_params": {
-                    "model": "gpt-3.5-turbo-1106",
-                    "input_cost_per_token": 0.0000005,
-                    "output_cost_per_token": 0.0000015
+                    "model": "gpt-4o-mini",
+                    "input_cost_per_token": 0.000000015,
+                    "output_cost_per_token": 0.0000006
                 }
             },
             {

--- a/examples/code_review/main.py
+++ b/examples/code_review/main.py
@@ -41,13 +41,13 @@ print(f"GENERATED REVIEW: \n {review_desc}")
 print(f"\nComment and topics: \n {json.dumps(comments, indent=2)}, \n{topics}")
 
 
-# print("---------------Generate desc-------------")
-# pr_desc = PRDescriptionGenerator(llm_provider=LLMProvider())
-# desc_data = pr_desc.generate_pull_request_desc(
-#     diff_text=None,
-#     pull_request_title=pr_title,
-#     pull_request_desc="",
-#     pull_request_files=pr_files,
-#     user="kaizen/example",
-# )
-# print(desc_data)
+print("---------------Generate desc-------------")
+pr_desc = PRDescriptionGenerator(llm_provider=LLMProvider())
+desc_data = pr_desc.generate_pull_request_desc(
+    diff_text=None,
+    pull_request_title=pr_title,
+    pull_request_desc="",
+    pull_request_files=pr_files,
+    user="kaizen/example",
+)
+print(desc_data)

--- a/examples/code_review/main.py
+++ b/examples/code_review/main.py
@@ -8,9 +8,12 @@ from github_app.github_helper.pull_requests import (
     create_review_comments,
 )
 import json
+import logging
 
-pr_diff = "https://github.com/Cloud-Code-AI/kaizen/pull/308.patch"
-pr_files = "https://api.github.com/repos/Cloud-Code-AI/kaizen/pulls/308/files"
+logging.basicConfig(level="DEBUG")
+
+pr_diff = "https://github.com/Cloud-Code-AI/kaizen/pull/335.patch"
+pr_files = "https://api.github.com/repos/Cloud-Code-AI/kaizen/pulls/335/files"
 pr_title = "feat: updated the prompt to provide solution"
 
 diff_text = get_diff_text(pr_diff, "")
@@ -38,13 +41,13 @@ print(f"GENERATED REVIEW: \n {review_desc}")
 print(f"\nComment and topics: \n {json.dumps(comments, indent=2)}, \n{topics}")
 
 
-print("---------------Generate desc-------------")
-pr_desc = PRDescriptionGenerator(llm_provider=LLMProvider())
-desc_data = pr_desc.generate_pull_request_desc(
-    diff_text=None,
-    pull_request_title=pr_title,
-    pull_request_desc="",
-    pull_request_files=pr_files,
-    user="kaizen/example",
-)
-print(desc_data)
+# print("---------------Generate desc-------------")
+# pr_desc = PRDescriptionGenerator(llm_provider=LLMProvider())
+# desc_data = pr_desc.generate_pull_request_desc(
+#     diff_text=None,
+#     pull_request_title=pr_title,
+#     pull_request_desc="",
+#     pull_request_files=pr_files,
+#     user="kaizen/example",
+# )
+# print(desc_data)

--- a/kaizen/helpers/parser.py
+++ b/kaizen/helpers/parser.py
@@ -181,6 +181,10 @@ def patch_to_separate_chunks(patch_text):
 
     return "\n".join(output)
 
+def format_change(old_num, new_num, change_type, content):
+    old_num_str = f"{old_num:<4}" if old_num is not None else "    "
+    new_num_str = f"{new_num:<4}" if new_num is not None else "    "
+    return f"{old_num_str} {new_num_str} {change_type} {content}"
 
 def patch_to_combined_chunks(patch_text):
     lines = patch_text.split("\n")
@@ -228,17 +232,17 @@ def patch_to_combined_chunks(patch_text):
             line = line.replace("a/", "").replace("b/", "").replace("+++ ", "")
             current_file_name = line
         elif line.startswith("-"):
-            line = "<->   " + line[1:]
-            changes.append(f"{removal_line_num:<4} {line}")
+            content = line[1:]
+            changes.append(format_change(removal_line_num, None, "<->", content))
             removal_line_num += 1
             unedited_removal_num = removal_line_num
         elif line.startswith("+"):
-            line = "<+>   " + line[1:]
-            changes.append(f"{addition_line_num:<4} {line}")
+            content = line[1:]
+            changes.append(format_change(None, addition_line_num, "<+>", content))
             addition_line_num += 1
             unedited_addition_num = addition_line_num
         else:
-            changes.append(f"{unedited_removal_num:<4} <.>   {line}")
+            changes.append(format_change(unedited_removal_num, unedited_addition_num, "<.>", line))
             unedited_removal_num += 1
             unedited_addition_num += 1
             removal_line_num += 1

--- a/kaizen/helpers/parser.py
+++ b/kaizen/helpers/parser.py
@@ -113,12 +113,19 @@ def patch_to_separate_chunks(patch_text):
     unedited_count = 0
     current_hunk = None
     is_diff = False
-
+    first_transition = True
+    current_file_name = ""
     for line in lines:
         if "diff --git" in line:
             is_diff = True
-            removals.append("~~~~~~~~~~")
-            additions.append("~~~~~~~~~~")
+            if first_transition:
+                removals = []
+                additions = []
+                first_transition = False
+                continue
+            removals.append("\n</change_block>\n\n")
+            additions.append("\n</change_block>\n\n")
+            
         elif is_diff:
             is_diff = False
         elif line.startswith("@"):
@@ -129,16 +136,28 @@ def patch_to_separate_chunks(patch_text):
             if match:
                 removal_line_num = int(match.group(1))
                 addition_line_num = int(match.group(2))
-                removals.append("=====")
-                additions.append("=====")
+                if removals:
+                    removals.append("</change_block>")
+                if additions:
+                    additions.append("</change_block>")
+                removals.append("\n<change_block>")
+                removals.append(f"Filename: {current_file_name}\n")
+                additions.append("\n<change_block>")
+                additions.append(f"Filename: {current_file_name}\n")
+                # removals.append(current_hunk + "\n")
+                # additions.append(current_hunk + "\n")
         elif line.startswith("---"):
-            removals.append(f"{0:<4} {line}")
+            line = line.replace("a/", "").replace("b/", "").replace("--- ", "")
+            current_file_name = line
         elif line.startswith("+++"):
-            additions.append(f"{0:<4} {line}")
+            line = line.replace("a/", "").replace("b/", "").replace("+++ ", "")
+            current_file_name = line
         elif line.startswith("-"):
+            line = "<-> " + line[1:]
             removals.append(f"{removal_line_num:<4} {line}")
             removal_line_num += 1
         elif line.startswith("+"):
+            line = "<+> " + line[1:]
             additions.append(f"{addition_line_num:<4} {line}")
             addition_line_num += 1
         else:
@@ -150,12 +169,87 @@ def patch_to_separate_chunks(patch_text):
 
     if current_hunk:
         metadata.append(current_hunk)
+        removals.append("</change_block>\n\n")
+        additions.append("</change_block>\n\n")
 
-    output = ["Metadata:"]
-    output.extend(metadata)
-    output.append(f"\nRemovals: (including {unedited_count} unedited lines)")
+
+    output = []
+    output.append(f"\n##Removals: (including {unedited_count} unedited lines)\n")
     output.extend(removals)
-    output.append(f"\nAdditions: (including {unedited_count} unedited lines)")
+    output.append(f"\n\n\n##Additions: (including {unedited_count} unedited lines)\n")
     output.extend(additions)
+
+    return "\n".join(output)
+
+
+def patch_to_combined_chunks(patch_text):
+    lines = patch_text.split("\n")
+    changes = []
+    metadata = []
+    removal_line_num = 0
+    addition_line_num = 0
+    unedited_removal_num = 0
+    unedited_addition_num = 0
+    unedited_count = 0
+    current_hunk = None
+    is_diff = False
+    first_transition = True
+    current_file_name = ""
+    
+    for line in lines:
+        if "diff --git" in line:
+            is_diff = True
+            if not first_transition:
+                changes.append("\n</change_block>\n\n")
+            first_transition = False
+            
+        elif is_diff:
+            is_diff = False
+        elif line.startswith("@"):
+            if current_hunk:
+                metadata.append(current_hunk)
+            current_hunk = line
+            match = re.match(r"@@ -(\d+),\d+ \+(\d+),\d+ @@", line)
+            if match:
+                removal_line_num = int(match.group(1))
+                addition_line_num = int(match.group(2))
+                unedited_removal_num = removal_line_num
+                unedited_addition_num = addition_line_num
+                if changes:
+                    changes.append("\n</change_block>")
+                changes.append("\n<change_block>")
+                changes.append(f"Filename: {current_file_name}\n")
+        elif line.startswith("index "):
+            continue
+        elif line.startswith("---"):
+            line = line.replace("a/", "").replace("b/", "").replace("--- ", "")
+            current_file_name = line
+        elif line.startswith("+++"):
+            line = line.replace("a/", "").replace("b/", "").replace("+++ ", "")
+            current_file_name = line
+        elif line.startswith("-"):
+            line = "<->   " + line[1:]
+            changes.append(f"{removal_line_num:<4} {line}")
+            removal_line_num += 1
+            unedited_removal_num = removal_line_num
+        elif line.startswith("+"):
+            line = "<+>   " + line[1:]
+            changes.append(f"{addition_line_num:<4} {line}")
+            addition_line_num += 1
+            unedited_addition_num = addition_line_num
+        else:
+            changes.append(f"{unedited_removal_num:<4} <.>   {line}")
+            unedited_removal_num += 1
+            unedited_addition_num += 1
+            removal_line_num += 1
+            addition_line_num += 1
+            unedited_count += 1
+
+    if current_hunk:
+        metadata.append(current_hunk)
+        changes.append("</change_block>\n\n")
+
+    output = [f"\n##Changes: (including {unedited_count} unedited lines)\n"]
+    output.extend(changes)
 
     return "\n".join(output)

--- a/kaizen/helpers/parser.py
+++ b/kaizen/helpers/parser.py
@@ -125,7 +125,7 @@ def patch_to_separate_chunks(patch_text):
                 continue
             removals.append("\n</change_block>\n\n")
             additions.append("\n</change_block>\n\n")
-            
+
         elif is_diff:
             is_diff = False
         elif line.startswith("@"):
@@ -172,7 +172,6 @@ def patch_to_separate_chunks(patch_text):
         removals.append("</change_block>\n\n")
         additions.append("</change_block>\n\n")
 
-
     output = []
     output.append(f"\n##Removals: (including {unedited_count} unedited lines)\n")
     output.extend(removals)
@@ -181,10 +180,12 @@ def patch_to_separate_chunks(patch_text):
 
     return "\n".join(output)
 
+
 def format_change(old_num, new_num, change_type, content):
     old_num_str = f"{old_num:<4}" if old_num is not None else "    "
     new_num_str = f"{new_num:<4}" if new_num is not None else "    "
     return f"{old_num_str} {new_num_str} {change_type} {content}"
+
 
 def patch_to_combined_chunks(patch_text):
     lines = patch_text.split("\n")
@@ -199,14 +200,14 @@ def patch_to_combined_chunks(patch_text):
     is_diff = False
     first_transition = True
     current_file_name = ""
-    
+
     for line in lines:
         if "diff --git" in line:
             is_diff = True
             if not first_transition:
                 changes.append("\n</change_block>\n\n")
             first_transition = False
-            
+
         elif is_diff:
             is_diff = False
         elif line.startswith("@"):
@@ -242,7 +243,9 @@ def patch_to_combined_chunks(patch_text):
             addition_line_num += 1
             unedited_addition_num = addition_line_num
         else:
-            changes.append(format_change(unedited_removal_num, unedited_addition_num, "<.>", line))
+            changes.append(
+                format_change(unedited_removal_num, unedited_addition_num, "<.>", line)
+            )
             unedited_removal_num += 1
             unedited_addition_num += 1
             removal_line_num += 1

--- a/kaizen/llms/prompts/code_review_prompts.py
+++ b/kaizen/llms/prompts/code_review_prompts.py
@@ -5,7 +5,7 @@ As a senior software developer reviewing code submissions, provide thorough, con
 CODE_REVIEW_PROMPT = """
 As an experienced software engineer, provide a concise, actionable code review for the given pull request. Evaluate code changes, identify potential issues, and offer constructive feedback.
 
-Generate a JSON object with the following structure, including only sections with relevant feedback:
+Generate a JSON object with the following structure:
 {{
   "review": [
     {{
@@ -15,6 +15,7 @@ Generate a JSON object with the following structure, including only sections wit
       "reason": "<ISSUE_REASONING>",
       "solution": "<HIGH_LEVEL_SOLUTION>",
       "fixed_code": "<CORRECTED_CODE>",
+      "file_name": "<FULL_FILE_PATH>",
       "start_line": <START_LINE_NUMBER>,
       "end_line": <END_LINE_NUMBER>,
       "side": "LEFT|RIGHT",
@@ -24,56 +25,23 @@ Generate a JSON object with the following structure, including only sections wit
     }}
   ]
 }}
-Guidelines:
 
-Provide actionable feedback with specific file paths and line numbers
-Use markdown for code snippets
-Merge duplicate feedback
-Concise yet useful comments
-Examine: syntax/logic errors, loops, null values, resource leaks, race conditions, integration/performance issues, security vulnerabilities
-If no feedback: {{"review": []}}
+Guidelines:
+- Provide actionable feedback with specific file paths and line numbers
+- Use markdown for code snippets
+- Merge duplicate feedback
+- Examine: syntax/logic errors, loops, null values, resource leaks, race conditions, integration/performance issues, security vulnerabilities
+- If no feedback: {{"review": []}}
+
+Review Focus:
+1. Analyze removals (lines starting with '<->') to identify potential issues caused by the deletion of code.
+2. Provide feedback and code fixes primarily for additions (lines starting with '<+>').
+3. Consider the impact of both removals and additions on the overall functionality and structure of the code.
 
 Field Guidelines:
-- "fixed_code": Generate corrected code to replace the commented lines, ensuring changes are between start_line and end_line.
-- "start_line": The actual line number in the new file where the change begins. For added lines, this is the line number of the first '+' line in the chunk.
-- "end_line": The actual line number in the new file where the change ends. For added lines, this is the line number of the last '+' line in the chunk.
-- "side": Use "LEFT" for deleted lines, "RIGHT" for added lines (for GitHub review comments).
-- "file_name": Include the full file path for precise issue location.
-- "severity_level": Score from 1 (least severe) to 10 (most critical).
-
-Patch Data Processing:
-
-Git patch data consists of file information, chunk headers ("@@"), and content changes ('+' for additions, '-' for deletions). Unchanged lines provide context. Multiple chunks may exist per file.
-
-Key points:
-1. Changes can occur in multiple files
-2. A file may have multiple change chunks
-3. Line numbers in later chunks are affected by earlier changes
-4. Calculate actual line numbers in the new version, accounting for all previous changes
-
-Interpreting a diff hunk:
-1. Hunk header ("@@"): Shows affected line numbers in old and new versions
-2. Unchanged lines: No prefix, present in both versions
-3. Removed lines: Start with "-"
-4. Added lines: Start with "+" (exclude file headers "+++")
-
-Example:
-```
-@@ -82,7 +82,7 @@ def *retrieve*igd_profile(url):
-     Retrieve the device's UPnP profile.
-     try:
--        return urllib2.urlopen(url.geturl(), timeout=5).read()
-+        return urllib2.urlopen(url.geturl(), timeout=5).read().decode('utf-8')
-     except socket.error:
-         raise IGDError('IGD profile query timed out')
-```
-
-To interpret:
-1. Examine hunk header for context
-2. Identify removed lines ("-")
-3. Identify added lines ("+")
-4. Compare changes
-5. Use unchanged lines for context
+- "fixed_code": Provide corrected code only for additions, ensuring changes are between start_line and end_line.
+- "start_line" and "end_line": Actual line numbers in the new file where the change begins and ends
+- "severity_level": Score from 1 (least severe) to 10 (most critical)
 
 INFORMATION:
 
@@ -87,7 +55,7 @@ PATCH DATA:
 FILE_CODE_REVIEW_PROMPT = """
 As an experienced software engineer, provide a concise, actionable code review for the given pull request. Evaluate code changes, identify potential issues, and offer constructive feedback.
 
-Generate a JSON object with the following structure, including only sections with relevant feedback:
+Generate a JSON object with the following structure:
 {{
   "review": [
     {{
@@ -97,6 +65,7 @@ Generate a JSON object with the following structure, including only sections wit
       "reason": "<ISSUE_REASONING>",
       "solution": "<HIGH_LEVEL_SOLUTION>",
       "fixed_code": "<CORRECTED_CODE>",
+      "file_name": "<FULL_FILE_PATH>",
       "start_line": <START_LINE_NUMBER>,
       "end_line": <END_LINE_NUMBER>,
       "side": "LEFT|RIGHT",
@@ -106,56 +75,24 @@ Generate a JSON object with the following structure, including only sections wit
     }}
   ]
 }}
-Guidelines:
 
-Provide actionable feedback with specific file paths and line numbers
-Use markdown for code snippets
-Merge duplicate feedback
-Concise yet useful comments
-Examine: syntax/logic errors, loops, null values, resource leaks, race conditions, integration/performance issues, security vulnerabilities
-If no feedback: {{"review": []}}
+Guidelines:
+- Provide actionable feedback with specific file paths and line numbers
+- Use markdown for code snippets
+- Merge duplicate feedback
+- Examine: syntax/logic errors, loops, null values, resource leaks, race conditions, integration/performance issues, security vulnerabilities
+- If no feedback: {{"review": []}}
+
+Review Focus:
+1. Analyze removals (lines starting with '<->') to identify potential issues caused by the deletion of code.
+2. Provide feedback and code fixes primarily for additions (lines starting with '<+>').
+3. Consider the impact of both removals and additions on the overall functionality and structure of the code.
+4. '<.>' indicates no changes were made in this line.
 
 Field Guidelines:
-- "fixed_code": Generate corrected code to replace the commented lines, ensuring changes are between start_line and end_line.
-- "start_line": The actual line number in the new file where the change begins. For added lines, this is the line number of the first '+' line in the chunk.
-- "end_line": The actual line number in the new file where the change ends. For added lines, this is the line number of the last '+' line in the chunk.
-- "side": Use "LEFT" for deleted lines, "RIGHT" for added lines (for GitHub review comments).
-- "file_name": Include the full file path for precise issue location.
-- "severity_level": Score from 1 (least severe) to 10 (most critical).
-
-Patch Data Processing:
-
-Git patch data consists of file information, chunk headers ("@@"), and content changes ('+' for additions, '-' for deletions). Unchanged lines provide context. Multiple chunks may exist per file.
-
-Key points:
-1. Changes can occur in multiple files
-2. A file may have multiple change chunks
-3. Line numbers in later chunks are affected by earlier changes
-4. Calculate actual line numbers in the new version, accounting for all previous changes
-
-Interpreting a diff hunk:
-1. Hunk header ("@@"): Shows affected line numbers in old and new versions
-2. Unchanged lines: No prefix, present in both versions
-3. Removed lines: Start with "-"
-4. Added lines: Start with "+" (exclude file headers "+++")
-
-Example:
-```
-@@ -82,7 +82,7 @@ def *retrieve*igd_profile(url):
-     Retrieve the device's UPnP profile.
-     try:
--        return urllib2.urlopen(url.geturl(), timeout=5).read()
-+        return urllib2.urlopen(url.geturl(), timeout=5).read().decode('utf-8')
-     except socket.error:
-         raise IGDError('IGD profile query timed out')
-```
-
-To interpret:
-1. Examine hunk header for context
-2. Identify removed lines ("-")
-3. Identify added lines ("+")
-4. Compare changes
-5. Use unchanged lines for context
+- "fixed_code": Provide corrected code only for additions, ensuring changes are between start_line and end_line.
+- "start_line" and "end_line": Actual line numbers in the new file where the change begins and ends
+- "severity_level": Score from 1 (least severe) to 10 (most critical)
 
 INFORMATION:
 

--- a/kaizen/llms/prompts/code_review_prompts.py
+++ b/kaizen/llms/prompts/code_review_prompts.py
@@ -34,9 +34,19 @@ Guidelines:
 - If no feedback: {{"review": []}}
 
 Review Focus:
-1. Analyze removals (lines starting with '<->') to identify potential issues caused by the deletion of code.
-2. Provide feedback and code fixes primarily for additions (lines starting with '<+>').
-3. Consider the impact of both removals and additions on the overall functionality and structure of the code.
+1. Analyze removals ('<->')
+2. Provide feedback for additions ('<+>')
+3. Consider impact of changes on code
+4. Note unchanged lines ('<.>')
+
+Patch Data Format:
+- First column: Original file line numbers
+- Second column: New file line numbers
+- Third column: Change type
+  '<->': Line removed (first column)
+  '<+>': Line added (last column)
+  '<.>': Unchanged line (both columns)
+- Remaining columns: Code content
 
 Field Guidelines:
 - "fixed_code": Provide corrected code only for additions, ensuring changes are between start_line and end_line.
@@ -84,10 +94,19 @@ Guidelines:
 - If no feedback: {{"review": []}}
 
 Review Focus:
-1. Analyze removals (lines starting with '<->') to identify potential issues caused by the deletion of code.
-2. Provide feedback and code fixes primarily for additions (lines starting with '<+>').
-3. Consider the impact of both removals and additions on the overall functionality and structure of the code.
-4. '<.>' indicates no changes were made in this line.
+1. Analyze removals ('<->')
+2. Provide feedback for additions ('<+>')
+3. Consider impact of changes on code
+4. Note unchanged lines ('<.>')
+
+Patch Data Format:
+- First column: Original file line numbers
+- Second column: New file line numbers
+- Third column: Change type
+  '<->': Line removed (first column)
+  '<+>': Line added (last column)
+  '<.>': Unchanged line (both columns)
+- Remaining columns: Code content
 
 Field Guidelines:
 - "fixed_code": Provide corrected code only for additions, ensuring changes are between start_line and end_line.

--- a/kaizen/reviewer/code_review.py
+++ b/kaizen/reviewer/code_review.py
@@ -40,7 +40,7 @@ class CodeReviewer:
         prompt = CODE_REVIEW_PROMPT.format(
             PULL_REQUEST_TITLE=pull_request_title,
             PULL_REQUEST_DESC=pull_request_desc,
-            CODE_DIFF=parser.patch_to_separate_chunks(diff_text),
+            CODE_DIFF=parser.patch_to_combined_chunks(diff_text),
         )
         return self.provider.is_inside_token_limit(PROMPT=prompt)
 
@@ -56,7 +56,7 @@ class CodeReviewer:
         prompt = CODE_REVIEW_PROMPT.format(
             PULL_REQUEST_TITLE=pull_request_title,
             PULL_REQUEST_DESC=pull_request_desc,
-            CODE_DIFF=parser.patch_to_separate_chunks(diff_text),
+            CODE_DIFF=parser.patch_to_combined_chunks(diff_text),
         )
         self.total_usage = {
             "prompt_tokens": 0,
@@ -143,7 +143,7 @@ class CodeReviewer:
             ):
                 temp_prompt = (
                     combined_diff_data
-                    + f"\n---->\nFile Name: {filename}\nPatch Details: {parser.patch_to_separate_chunks(patch_details)}"
+                    + f"\n---->\nFile Name: {filename}\nPatch Details: {parser.patch_to_combined_chunks(patch_details)}"
                 )
 
                 if available_tokens - self.provider.get_token_count(temp_prompt) > 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cloudcode"
-version = "0.3.10"
+version = "0.3.11"
 description = "An intelligent coding companion that accelerates your development workflow by providing efficient assistance, enabling you to craft high-quality code more rapidly."
 authors = ["Saurav Panda <saurav.panda@cloudcode.ai>"]
 license = "Apache2.0"

--- a/tests/helpers/test_patch_parser.py
+++ b/tests/helpers/test_patch_parser.py
@@ -1,4 +1,4 @@
-from kaizen.helpers.parser import patch_to_separate_chunks
+from kaizen.helpers.parser import patch_to_combined_chunks
 
 patch_data = '''
 From b82fcf4f6392a54bc8bfa6d099fb838f9293f448 Mon Sep 17 00:00:00 2001
@@ -107,4 +107,424 @@ index 95c754f..4b35bcc 100644
  license = "Apache2.0"
 '''
 
-print(patch_to_separate_chunks(patch_text=patch_data))
+patch_data2 = '''
+From d3f483e4f6a9d3b6322e0baaeb1d1bc15fed3cc6 Mon Sep 17 00:00:00 2001
+From: Saurav Panda <sgp65@cornell.edu>
+Date: Thu, 18 Jul 2024 09:42:03 -0700
+Subject: [PATCH] feat: added standard output format for description generation
+
+---
+ kaizen/generator/pr_description.py         |  51 ++------
+ kaizen/llms/prompts/code_review_prompts.py | 140 ---------------------
+ kaizen/llms/prompts/pr_desc_prompts.py     |  92 ++++++++++++++
+ 3 files changed, 105 insertions(+), 178 deletions(-)
+ create mode 100644 kaizen/llms/prompts/pr_desc_prompts.py
+
+diff --git a/kaizen/generator/pr_description.py b/kaizen/generator/pr_description.py
+index e4f548c..e8a4635 100644
+--- a/kaizen/generator/pr_description.py
++++ b/kaizen/generator/pr_description.py
+@@ -5,12 +5,11 @@
+ 
+ from kaizen.helpers import output, parser
+ from kaizen.llms.provider import LLMProvider
+-from kaizen.llms.prompts.code_review_prompts import (
++from kaizen.llms.prompts.pr_desc_prompts import (
+     PR_DESCRIPTION_PROMPT,
+     MERGE_PR_DESCRIPTION_PROMPT,
+     PR_FILE_DESCRIPTION_PROMPT,
+-    PR_DESC_EVALUATION_PROMPT,
+-    CODE_REVIEW_SYSTEM_PROMPT,
++    PR_DESCRIPTION_SYSTEM_PROMPT,
+ )
+ 
+ 
+@@ -26,7 +25,7 @@ class PRDescriptionGenerator:
+     def __init__(self, llm_provider: LLMProvider):
+         self.logger = logging.getLogger(__name__)
+         self.provider = llm_provider
+-        self.provider.system_prompt = CODE_REVIEW_SYSTEM_PROMPT
++        self.provider.system_prompt = PR_DESCRIPTION_SYSTEM_PROMPT
+         self.total_usage = {
+             "prompt_tokens": 0,
+             "completion_tokens": 0,
+@@ -40,7 +39,6 @@ def generate_pull_request_desc(
+         pull_request_desc: str,
+         pull_request_files: List[Dict],
+         user: Optional[str] = None,
+-        reeval_response: bool = False,
+     ) -> DescOutput:
+         prompt = PR_DESCRIPTION_PROMPT.format(
+             PULL_REQUEST_TITLE=pull_request_title,
+@@ -51,14 +49,13 @@ def generate_pull_request_desc(
+             raise Exception("Both diff_text and pull_request_files are empty!")
+ 
+         if diff_text and self.provider.is_inside_token_limit(PROMPT=prompt):
+-            desc = self._process_full_diff(prompt, user, reeval_response)
++            desc = self._process_full_diff(prompt, user)
+         else:
+             desc = self._process_files(
+                 pull_request_files,
+                 pull_request_title,
+                 pull_request_desc,
+                 user,
+-                reeval_response,
+             )
+ 
+         body = output.create_pr_description(desc, pull_request_desc)
+@@ -77,15 +74,13 @@ def _process_full_diff(
+         self,
+         prompt: str,
+         user: Optional[str],
+-        reeval_response: bool,
+     ) -> str:
+         self.logger.debug("Processing directly from diff")
+-        resp, usage = self.provider.chat_completion_with_json(prompt, user=user)
++        resp, usage = self.provider.chat_completion(prompt, user=user)
++        desc = parser.extract_code_from_markdown(resp)
+         self.total_usage = self.provider.update_usage(self.total_usage, usage)
+ 
+-        if reeval_response:
+-            resp = self._reevaluate_response(prompt, resp, user)
+-        return resp["desc"]
++        return desc
+ 
+     def _process_files(
+         self,
+@@ -93,7 +88,6 @@ def _process_files(
+         pull_request_title: str,
+         pull_request_desc: str,
+         user: Optional[str],
+-        reeval_response: bool,
+     ) -> List[Dict]:
+         self.logger.debug("Processing based on files")
+         file_descs = []
+@@ -102,15 +96,15 @@ def _process_files(
+             pull_request_title,
+             pull_request_desc,
+             user,
+-            reeval_response,
+         ):
+             file_descs.extend(file_review)
+ 
+         prompt = MERGE_PR_DESCRIPTION_PROMPT.format(DESCS=json.dumps(file_descs))
+-        resp, usage = self.provider.chat_completion_with_json(prompt, user=user)
++        resp, usage = self.provider.chat_completion(prompt, user=user)
++        desc = parser.extract_code_from_markdown(resp)
+         self.total_usage = self.provider.update_usage(self.total_usage, usage)
+ 
+-        return resp["desc"]
++        return desc
+ 
+     def _process_files_generator(
+         self,
+@@ -118,7 +112,6 @@ def _process_files_generator(
+         pull_request_title: str,
+         pull_request_desc: str,
+         user: Optional[str],
+-        reeval_response: bool,
+     ) -> Generator[List[Dict], None, None]:
+         combined_diff_data = ""
+         available_tokens = self.provider.available_tokens(
+@@ -151,7 +144,6 @@ def _process_files_generator(
+                     pull_request_title,
+                     pull_request_desc,
+                     user,
+-                    reeval_response,
+                 )
+                 combined_diff_data = (
+                     f"\n---->\nFile Name: {filename}\nPatch Details: {patch_details}"
+@@ -163,7 +155,6 @@ def _process_files_generator(
+                 pull_request_title,
+                 pull_request_desc,
+                 user,
+-                reeval_response,
+             )
+ 
+     def _process_file_chunk(
+@@ -172,30 +163,14 @@ def _process_file_chunk(
+         pull_request_title: str,
+         pull_request_desc: str,
+         user: Optional[str],
+-        reeval_response: bool,
+     ) -> List[Dict]:
+         prompt = PR_FILE_DESCRIPTION_PROMPT.format(
+             PULL_REQUEST_TITLE=pull_request_title,
+             PULL_REQUEST_DESC=pull_request_desc,
+             CODE_DIFF=diff_data,
+         )
+-        resp, usage = self.provider.chat_completion_with_json(prompt, user=user)
++        resp, usage = self.provider.chat_completion(prompt, user=user)
++        desc = parser.extract_code_from_markdown(resp)
+         self.total_usage = self.provider.update_usage(self.total_usage, usage)
+ 
+-        if reeval_response:
+-            resp = self._reevaluate_response(prompt, resp, user)
+-
+-        return resp["desc"]
+-
+-    def _reevaluate_response(self, prompt: str, resp: str, user: Optional[str]) -> str:
+-        messages = [
+-            {"role": "system", "content": self.provider.system_prompt},
+-            {"role": "user", "content": prompt},
+-            {"role": "assistant", "content": resp},
+-            {"role": "user", "content": PR_DESC_EVALUATION_PROMPT},
+-        ]
+-        resp, usage = self.provider.chat_completion(
+-            prompt, user=user, messages=messages
+-        )
+-        self.total_usage = self.provider.update_usage(self.total_usage, usage)
+-        return resp
++        return desc
+diff --git a/kaizen/llms/prompts/code_review_prompts.py b/kaizen/llms/prompts/code_review_prompts.py
+index 04c1181..5942fff 100644
+--- a/kaizen/llms/prompts/code_review_prompts.py
++++ b/kaizen/llms/prompts/code_review_prompts.py
+@@ -166,146 +166,6 @@
+ ```{FILE_PATCH}```
+ """
+ 
+-PR_DESCRIPTION_PROMPT = """
+-As a skilled developer reviewing a pull request, generate a concise and well-formatted description summarizing the main purpose, scope of changes, significant modifications, refactoring, or new features introduced in the pull request.
+-
+-Provide the output in the following JSON format:
+-
+-{{
+-  "desc": "
+-### Summary
+-
+-<Brief one-line summary of the pull request>
+-
+-### Details
+-
+-<Detailed multi-line description in markdown format>
+-- List of key changes
+-- New features
+-- Refactoring details
+-  "
+-}}
+-
+-When generating the description:
+-
+-- Create a concise and clear summary highlighting the main purpose of the pull request.
+-- Use markdown formatting in the detailed description for better readability.
+-- Organize the details into relevant sections or bullet points.
+-- Focus on the most significant aspects of the changes.
+-- Avoid repeating information already present in the pull request title or description.
+-- Ensure the output is in valid JSON format.
+-
+-Based on the provided information:
+-
+-Pull Request Title: {PULL_REQUEST_TITLE}
+-Pull Request Description: {PULL_REQUEST_DESC}
+-Patch Data:
+-{CODE_DIFF}
+-
+-Analyze the information thoroughly and generate a comprehensive summary and detailed description.
+-Use your expertise to identify and highlight the most important aspects of the changes without asking for additional clarification. If certain details are unclear, make reasonable inferences based on the available information and your development experience.
+-
+-"""
+-
+-PR_FILE_DESCRIPTION_PROMPT = """
+-As a skilled developer reviewing a pull request, generate a concise and well-formatted description summarizing the main purpose, scope of changes, significant modifications, refactoring, or new features introduced in the pull request.
+-
+-Provide the output in the following JSON format:
+-
+-{{
+-  "desc": "
+-### Summary
+-
+-<Brief one-line summary of the pull request>
+-
+-### Details
+-
+-<Detailed multi-line description in markdown format>
+-- List of key changes
+-- New features
+-- Refactoring details
+-  "
+-}}
+-
+-When generating the description:
+-
+-- Create a concise and clear summary highlighting the main purpose of the pull request.
+-- Use markdown formatting in the detailed description for better readability.
+-- Organize the details into relevant sections or bullet points.
+-- Focus on the most significant aspects of the changes.
+-- Avoid repeating information already present in the pull request title or description.
+-- Ensure the output is in valid JSON format.
+-
+-Based on the provided information:
+-
+-Pull Request Title: {PULL_REQUEST_TITLE}
+-Pull Request Description: {PULL_REQUEST_DESC}
+-Patch Data:
+-{CODE_DIFF}
+-
+-Analyze the information thoroughly and generate a comprehensive summary and detailed description.
+-Use your expertise to identify and highlight the most important aspects of the changes without asking for additional clarification. If certain details are unclear, make reasonable inferences based on the available information and your development experience.
+-"""
+-
+-MERGE_PR_DESCRIPTION_PROMPT = """
+-As a skilled developer reviewing a pull request, generate a concise and well-formatted description that synthesizes multiple PR descriptions into a single, comprehensive summary. This summary should encapsulate the main purpose, scope of changes, significant modifications, refactoring, and new features introduced in the pull request.
+-
+-Using the provided PR descriptions in JSON format, create a merged PR Description in the following JSON format:
+-
+-{{
+-  "desc": "
+-### Summary
+-
+-<Brief one-line summary encompassing the overall purpose of the pull request>
+-
+-### Details
+-
+-<Detailed multi-line description in markdown format>
+-- Consolidated list of key changes
+-- Aggregated new features
+-- Combined refactoring details
+-- Other significant aspects from all descriptions
+-  "
+-}}
+-
+-When generating the merged description:
+-
+-- Create a concise yet comprehensive summary that captures the essence of all provided descriptions.
+-- Use markdown formatting in the detailed description for improved readability.
+-- Organize the details into relevant sections or bullet points, consolidating similar information from different descriptions.
+-- Focus on the most significant aspects of the changes across all descriptions.
+-- Eliminate redundancies and repetitions while ensuring all unique and important points are included.
+-- Ensure the output is in valid JSON format.
+-
+-Analyze the provided PR descriptions thoroughly and generate a unified, comprehensive summary and detailed description. Use your expertise to identify, merge, and highlight the most important aspects of the changes across all descriptions. If certain details seem contradictory or unclear, use your best judgment to provide the most accurate and coherent representation of the pull request's purpose and changes.
+-
+-Here is the information:
+-{DESCS}
+-"""
+-
+-PR_DESC_EVALUATION_PROMPT = """
+-Please evaluate the accuracy and completeness of your previous responses in this conversation.
+-Identify any potential errors or areas for improvement.
+-
+-Respond the JSON output as:
+-{{
+-  "desc": "
+-### Summary
+-
+-<Brief one-line summary encompassing the overall purpose of the pull request>
+-
+-### Details
+-
+-<Detailed multi-line description in markdown format>
+-- Consolidated list of key changes
+-- Aggregated new features
+-- Combined refactoring details
+-- Other significant aspects from all descriptions
+-  "
+-}}
+-
+-"""
+-
+ 
+ PR_REVIEW_EVALUATION_PROMPT = """
+ Please evaluate the accuracy and completeness of your previous responses in this conversation.
+diff --git a/kaizen/llms/prompts/pr_desc_prompts.py b/kaizen/llms/prompts/pr_desc_prompts.py
+new file mode 100644
+index 0000000..3800d67
+--- /dev/null
++++ b/kaizen/llms/prompts/pr_desc_prompts.py
+@@ -0,0 +1,92 @@
++PR_DESCRIPTION_SYSTEM_PROMPT = """
++As a senior software developer reviewing code submissions, provide thorough, constructive feedback and suggestions for improvements. Consider best practices, error handling, performance, readability, and maintainability. Offer objective and respectful reviews that help developers enhance their skills and code quality. Use your expertise to provide comprehensive feedback without asking clarifying questions.
++"""
++
++PR_DESCRIPTION_PROMPT = """
++Summarize the main purpose, scope of changes, significant modifications, refactoring, or new features in this pull request.
++
++Output Format:
++```markdown
++# {{Generated PR Title}}
++
++## Overview
++{{Brief summary of overall purpose}}
++
++## Changes
++- Key Changes: {{List main modifications}}
++- New Features: {{List key new features}}
++- Refactoring: {{List main refactoring changes}}
++```
++
++Instructions:
++- Create a concise summary of the PR's main purpose.
++- Use markdown formatting for readability.
++- Focus on significant changes and avoid repetition.
++
++Based on:
++Title: {PULL_REQUEST_TITLE}
++Description: {PULL_REQUEST_DESC}
++Patch:
++{CODE_DIFF}
++
++Analyze the information and generate a comprehensive summary. Make reasonable inferences for unclear details based on your development experience.
++"""
++
++PR_FILE_DESCRIPTION_PROMPT = """
++Summarize the main purpose, scope of changes, significant modifications, refactoring, or new features in this pull request file.
++
++Output Format:
++```markdown
++# {{Generated PR Title}}
++
++## Overview
++{{Brief summary of file changes}}
++
++## Details
++- Main Changes: {{List key modifications}}
++- New Features: {{List new features, if any}}
++- Refactoring: {{List refactoring changes, if any}}
++```
++
++Instructions:
++- Create a concise summary of the file changes.
++- Use markdown formatting for readability.
++- Focus on significant changes and avoid repetition.
++
++Based on:
++Title: {PULL_REQUEST_TITLE}
++Description: {PULL_REQUEST_DESC}
++Patch:
++{CODE_DIFF}
++
++Analyze the information and generate a comprehensive summary. Make reasonable inferences for unclear details based on your development experience.
++"""
++
++MERGE_PR_DESCRIPTION_PROMPT = """
++Synthesize multiple PR descriptions into a single, comprehensive summary. Create a markdown-formatted description that captures the main purpose, scope of changes, and significant modifications.
++
++Output Format:
++```markdown
++# {{Generated PR Title}}
++
++## Overview
++{{Brief summary of overall purpose}}
++
++## Changes
++- New Features: {{List key new features}}
++- Refactoring: {{List main refactoring changes}}
++- Other Changes: {{List other significant modifications}}
++```
++
++Instructions:
++- Capture the essence of all descriptions concisely.
++- Use markdown formatting for readability.
++- Organize details into the specified sections.
++- Focus on the most significant aspects across all descriptions.
++- Ensure all unique and important points are included.
++
++Analyze the provided PR descriptions and generate a unified summary. Use your judgment to resolve any contradictions or unclear points.
++
++Here is the information:
++{DESCS}
++"""
+'''
+
+print(patch_to_combined_chunks(patch_text=patch_data2))


### PR DESCRIPTION
### Summary

This pull request updates the prompt used for pull request reviews based on a new method for passing pull request data.

### Details

- **Refactoring:** The `patch_to_separate_chunks` method in the `kaizen/helpers/parser.py` file has been replaced with `patch_to_combined_chunks`. This change likely aims to modify how code diffs are formatted and presented to the code review prompt.
- **New Feature:** The `file_name` field has been added to the JSON structure used for code review feedback. This allows for more precise identification of the file where issues are found.
- **Version Bump:** The `pyproject.toml` file has been updated to reflect the new version `0.3.11`.
- **Potential Impact:** The change in the prompt format might affect the code review feedback generated by the LLM. It's important to test the new prompt with various code changes to ensure the quality and accuracy of the feedback remain consistent.


> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
None
</details>

