### PR TITLE
fix: respond to code review even if now files to process

### DIFF
--- a/kaizen/reviewer/code_review.py
+++ b/kaizen/reviewer/code_review.py
@@ -164,14 +164,13 @@ class CodeReviewer:
                     f"\n---->\nFile Name: {filename}\nPatch Details: {patch_details}"
                 )
 
-        if combined_diff_data:
-            yield self._process_file_chunk(
-                combined_diff_data,
-                pull_request_title,
-                pull_request_desc,
-                user,
-                reeval_response,
-            )
+        yield self._process_file_chunk(
+            combined_diff_data,
+            pull_request_title,
+            pull_request_desc,
+            user,
+            reeval_response,
+        )
 
     def _process_file_chunk(
         self,


### PR DESCRIPTION
# Fix: Respond to Code Review Even If No Files to Process

## Overview
This pull request addresses an issue where the code review process would not yield a response if there were no files to process. The change ensures that the review process continues to function correctly, even in the absence of file data.

## Changes
- Key Changes: 
  - Removed the conditional check for `combined_diff_data` before yielding the processed file chunk, allowing the function to yield a response regardless of whether there are files to process.
  
- New Features: 
  - None explicitly introduced, but the change improves the robustness of the code review process.

- Refactoring: 
  - Simplified the logic in the `_process_files_generator` method by eliminating unnecessary conditional checks, enhancing readability and maintainability.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
None
</details>

