### PR TITLE
chore: add Rust example for unit test runner

### DIFF
--- a/examples/unittest/rust.py
+++ b/examples/unittest/rust.py
@@ -1,0 +1,52 @@
+from kaizen.generator.unit_test import UnitTestGenerator
+
+generator = UnitTestGenerator()
+code = '''
+struct Calculator {
+    result: i32,
+}
+
+impl Calculator {
+    fn new() -> Calculator {
+        Calculator { result: 0 }
+    }
+
+    fn add(&mut self, a: i32, b: i32) -> i32 {
+        self.result = a + b;
+        self.result
+    }
+
+    fn subtract(&mut self, a: i32, b: i32) -> i32 {
+        self.result = a - b;
+        self.result
+    }
+
+    fn get_result(&self) -> i32 {
+        self.result
+    }
+}
+
+fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+
+fn main() {
+    let mut calc = Calculator::new();
+    println!("{}", calc.add(5, 3));  // Should print 8
+    println!("{}", calc.subtract(10, 4));  // Should print 6
+    println!("{}", calc.get_result());  // Should print 6
+    println!("{}", greet("Alice"));  // Should print "Hello, Alice!"
+}
+'''
+
+test_results = generator.run_tests()
+
+for file_path, result in test_results.items():
+    print(f"Results for {file_path}:")
+    if "error" in result:
+        print(f"  Error: {result['error']}")
+    else:
+        print(f"  Tests run: {result.get('tests_run', 'N/A')}")
+        print(f"  Failures: {result.get('failures', 'N/A')}")
+        print(f"  Errors: {result.get('errors', 'N/A')}")
+    print()


### PR DESCRIPTION
# chore: add Rust example for unit test runner

## Overview
This pull request adds a new Rust example to the `examples/unittest` directory. The purpose is to demonstrate how to generate and run unit tests for Rust code using the `UnitTestGenerator` from the `kaizen.generator.unit_test` module.

## Changes
- Key Changes:
  - Added a new file `rust.py` in the `examples/unittest` directory
  - Implemented a simple `Calculator` struct with `add`, `subtract`, and `get_result` methods
  - Implemented a `greet` function that takes a name and returns a greeting
  - Included the Rust code in the `code` variable and used the `UnitTestGenerator` to run the tests
- New Features:
  - Provided an example of how to generate and run unit tests for Rust code using the `UnitTestGenerator`
- Refactoring:
  - No major refactoring changes were made in this pull request

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
Added an example in `examples/unittest` to generate and run tests for rust code.
Contains the following constructs:
- `module`
- `functions`
- `impl` block
</details>

