### PR TITLE
fix: bug in desc generation

### DIFF
--- a/kaizen/generator/pr_description.py
+++ b/kaizen/generator/pr_description.py
@@ -41,8 +41,6 @@ class PRDescriptionGenerator:
         user: Optional[str] = None,
     ) -> DescOutput:
         prompt = PR_DESCRIPTION_PROMPT.format(
-            PULL_REQUEST_TITLE=pull_request_title,
-            PULL_REQUEST_DESC=pull_request_desc,
             CODE_DIFF=diff_text,
         )
         if not diff_text and not pull_request_files:
@@ -116,8 +114,6 @@ class PRDescriptionGenerator:
         combined_diff_data = ""
         available_tokens = self.provider.available_tokens(
             PR_FILE_DESCRIPTION_PROMPT.format(
-                PULL_REQUEST_TITLE=pull_request_title,
-                PULL_REQUEST_DESC=pull_request_desc,
                 CODE_DIFF="",
             )
         )
@@ -165,8 +161,6 @@ class PRDescriptionGenerator:
         user: Optional[str],
     ) -> List[Dict]:
         prompt = PR_FILE_DESCRIPTION_PROMPT.format(
-            PULL_REQUEST_TITLE=pull_request_title,
-            PULL_REQUEST_DESC=pull_request_desc,
             CODE_DIFF=diff_data,
         )
         resp, usage = self.provider.chat_completion(prompt, user=user)

--- a/kaizen/llms/prompts/pr_desc_prompts.py
+++ b/kaizen/llms/prompts/pr_desc_prompts.py
@@ -28,9 +28,6 @@ Instructions:
 - Use markdown formatting for readability.
 - Focus on significant changes and avoid repetition.
 
-Based on:
-Title: {PULL_REQUEST_TITLE}
-Description: {PULL_REQUEST_DESC}
 Patch:
 {CODE_DIFF}
 
@@ -58,9 +55,6 @@ Instructions:
 - Use markdown formatting for readability.
 - Focus on significant changes and avoid repetition.
 
-Based on:
-Title: {PULL_REQUEST_TITLE}
-Description: {PULL_REQUEST_DESC}
 Patch:
 {CODE_DIFF}
 

--- a/kaizen/reviewer/code_review.py
+++ b/kaizen/reviewer/code_review.py
@@ -128,13 +128,9 @@ class CodeReviewer:
         user: Optional[str] = None,
         reeval_response: bool = False,
         model="default",
-        custom_prompt="",
     ) -> ReviewOutput:
         prompt = CODE_REVIEW_PROMPT.format(
-            PULL_REQUEST_TITLE=pull_request_title,
-            PULL_REQUEST_DESC=pull_request_desc,
             CODE_DIFF=parser.patch_to_combined_chunks(diff_text),
-            CUSTOM_PROMPT=custom_prompt,
         )
         self.total_usage = {
             "prompt_tokens": 0,
@@ -155,7 +151,6 @@ class CodeReviewer:
                 pull_request_desc,
                 user,
                 reeval_response,
-                custom_prompt=custom_prompt,
             )
 
         reviews.extend(self.check_sensitive_files(pull_request_files))
@@ -274,8 +269,6 @@ class CodeReviewer:
         if not diff_data:
             return []
         prompt = FILE_CODE_REVIEW_PROMPT.format(
-            PULL_REQUEST_TITLE=pull_request_title,
-            PULL_REQUEST_DESC=pull_request_desc,
             FILE_PATCH=diff_data,
         )
         custom_model = {"model": self.default_model}


### PR DESCRIPTION
# Refactor PR for PR Description Generator

## Overview
This pull request focuses on refactoring the code for the PR description generator in the Kaizen project. The main goal is to improve the readability, maintainability, and performance of the PR description generation process.

## Changes

### Key Changes
- Removed unnecessary placeholders (`{PULL_REQUEST_TITLE}` and `{PULL_REQUEST_DESC}`) from the prompts used in the PR description generation process.
- Simplified the prompt formatting by removing the redundant title and description information, as this information is already available in the context of the pull request.
- Consolidated the prompt formatting into a single location (`pr_desc_prompts.py`) to improve code organization and maintainability.

### Refactoring
- Refactored the `_process_file_chunk` method in the `_process_files_generator` function to remove the redundant title and description information from the prompt.
- Removed the `custom_prompt` parameter from the `review_pull_request` function, as it was not being used.
- Simplified the `review_pull_request` function by removing the unnecessary title and description information from the prompt.

Overall, these changes aim to streamline the PR description generation process by removing redundant information from the prompts and improving the code organization and maintainability.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>

</details>

