### PR TITLE
Updating license to MIT in docs

### DIFF
--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -104,7 +104,7 @@ export default {
     footer: {
         text: (
             <span>
-                AGPL {new Date().getFullYear()} ©{' '}
+                MIT {new Date().getFullYear()} ©{' '}
               <a href="https://cloudcode.ai" target="_blank">
                 Cloud Code AI
               </a>


### PR DESCRIPTION
# Update Footer License to MIT

- **Purpose:**
 Change the footer copyright license from AGPL to MIT.
- **Key Changes:**
  - Updated the footer copyright text to use the MIT license instead of AGPL.
  - Removed the trailing newline at the end of the file.
- **Impact:**
 This change will update the licensing information displayed in the website footer.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>

</details>

