### PR TITLE
feat: enhance commit message generation hook

### DIFF
--- a/cli/kaizen_cli/commands/config_commands.py
+++ b/cli/kaizen_cli/commands/config_commands.py
@@ -56,8 +56,8 @@ def show(obj):
 @config.command()
 @click.option("--name", required=True, help="Name of the model")
 @click.option("--model", required=True, help="LiteLLM model identifier")
-@click.option("--api-key", required=True, help="API key for the model")
-@click.option("--api-base", required=True, help="API base URL for the model")
+@click.option("--api-key", required=False, help="API key for the model", default=None)
+@click.option("--api-base", required=False, help="API base URL for the model", default=None)
 @click.pass_obj
 def add_model(obj, name, model, api_key, api_base):
     """Add or replace a model in the configuration."""

--- a/cli/kaizen_cli/hooks/prepare-commit-msg
+++ b/cli/kaizen_cli/hooks/prepare-commit-msg
@@ -8,7 +8,16 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 staged_diff=$(git diff --cached)
 
 # Run your CLI command and capture the output
-commit_info=$(kaizen-cli generate-commit-msg "$staged_diff")
+commit_info=$(kaizen-cli generate-commit-msg "$staged_diff" 2>/dev/null)
 
-# Write the commit info to the commit message file
-echo "$commit_info" > "$1"
+# Check if the command was successful
+if [ $? -eq 0 ] && [ -n "$commit_info" ]; then
+    # Write the commit info to the commit message file
+    echo "$commit_info" > "$1"
+else
+    # If there was an error or empty output, log it and exit successfully
+    echo "Warning: Failed to generate commit message. Using default." >&2
+fi
+
+# Always exit with success to allow the commit to proceed
+exit 0

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cli"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Saurav Panda <sgp65@cornell.edu>"]
 readme = "README.md"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cli"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = ["Saurav Panda <sgp65@cornell.edu>"]
 readme = "README.md"

--- a/kaizen/utils/config.py
+++ b/kaizen/utils/config.py
@@ -12,11 +12,16 @@ class ConfigData:
             with open("~/.kaizen_config.json", "r") as f:
                 self.config_data = json.loads(f.read())
         else:
-            print(f"Couldnt find config at {config_file} loading default vals")
             self.config_data = {
                 "language_model": {
                     "provider": "litellm",
                     "enable_observability_logging": False,
+                    "models": [
+                        {
+                            "model_name": "default",
+                            "litellm_params": {"model": "gpt-4o-mini"},
+                        },
+                    ],
                 },
                 "github_app": {
                     "check_signature": False,


### PR DESCRIPTION
# Add Optional API Key and Base URL for Models

- **Purpose:**
 Modify the `add_model` command in the CLI to make the API key and base URL optional.
- **Key Changes:**
  - Changed the `--api-key` and `--api-base` options in the `add_model` command to be optional, with default values of `None`.
  - Updated the `prepare-commit-msg` hook to handle cases where the `generate-commit-msg` command fails or produces empty output.
  - Bumped the CLI version to `0.2.4` in the `pyproject.toml` file.
  - Added a default model configuration to the `config.py` file.
- **Impact:**
 This change will allow users to add models to the configuration without providing an API key or base URL, making the CLI more flexible and easier to use.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>

</details>

