### PR TITLE
chore: update kaizen dependencies

### DIFF
--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -1454,7 +1454,7 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "kaizen-cloudcode"
-version = "0.4.12"
+version = "0.4.14"
 description = "An intelligent coding companion that accelerates your development workflow by providing efficient assistance, enabling you to craft high-quality code more rapidly."
 optional = false
 python-versions = "^3.9.0"
@@ -4370,4 +4370,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.0"
-content-hash = "d8dd0866cce15fa13755cf421b868b7e7fe5509dc7af511b18b210198ffeb8de"
+content-hash = "7c25823b4036e07641d63161c0b9b09abc268487a9ecd51e09ba32ca5ffa2350"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cli"
-version = "0.2.4"
+version = "0.2.5"
 description = ""
 authors = ["Saurav Panda <sgp65@cornell.edu>"]
 readme = "README.md"
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.9.0"
 click = "^8.1.3"
-kaizen-cloudcode = "^0.4.12"
+kaizen-cloudcode = "^0.4.14"
 
 [tool.poetry.group.dev.dependencies]
 kaizen-cloudcode = {path = "..", develop = true, optional = true}


### PR DESCRIPTION
# Upgrade kaizen-cloudcode to v0.4.14

- **Purpose:**
 Update the kaizen-cloudcode dependency to the latest version.
- **Key Changes:**
  - Bump kaizen-cloudcode version from 0.4.12 to 0.4.14
  - Update the poetry.lock file to reflect the new dependency version
- **Impact:**
 This change will provide the latest features and bug fixes from the kaizen-cloudcode library, improving the overall functionality and reliability of the CLI application.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>

</details>

