### PR TITLE
feat: enhance model configuration handling

### DIFF
--- a/cli/kaizen_cli/commands/config_commands.py
+++ b/cli/kaizen_cli/commands/config_commands.py
@@ -57,7 +57,9 @@ def show(obj):
 @click.option("--name", required=True, help="Name of the model")
 @click.option("--model", required=True, help="LiteLLM model identifier")
 @click.option("--api-key", required=False, help="API key for the model", default=None)
-@click.option("--api-base", required=False, help="API base URL for the model", default=None)
+@click.option(
+    "--api-base", required=False, help="API base URL for the model", default=None
+)
 @click.pass_obj
 def add_model(obj, name, model, api_key, api_base):
     """Add or replace a model in the configuration."""

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cli"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = ["Saurav Panda <sgp65@cornell.edu>"]
 readme = "README.md"

--- a/kaizen/llms/provider.py
+++ b/kaizen/llms/provider.py
@@ -82,7 +82,6 @@ class LLMProvider:
         provider_kwargs = {
             "model_list": self.models,
             "allowed_fails": 1,
-            "enable_pre_call_checks": True,
             "routing_strategy": "simple-shuffle",
         }
 

--- a/kaizen/utils/config.py
+++ b/kaizen/utils/config.py
@@ -1,15 +1,17 @@
 import json
 from pathlib import Path
+import os
 
 
 class ConfigData:
     def __init__(self, config_data=None):
-        config_file = "config.json"
-        if Path(config_file).is_file():
-            with open(config_file, "r") as f:
+        config_local_path = "config.json"
+        config_file_path = os.path.expanduser("~/.kaizen_config.json")
+        if Path(config_local_path).is_file():
+            with open(config_local_path, "r") as f:
                 self.config_data = json.loads(f.read())
-        elif Path("~/.kaizen_config.json").is_file():
-            with open("~/.kaizen_config.json", "r") as f:
+        elif Path(config_file_path).is_file():
+            with open(config_file_path, "r") as f:
                 self.config_data = json.loads(f.read())
         else:
             self.config_data = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kaizen-cloudcode"
-version = "0.4.14"
+version = "0.4.15"
 description = "An intelligent coding companion that accelerates your development workflow by providing efficient assistance, enabling you to craft high-quality code more rapidly."
 authors = ["Saurav Panda <saurav.panda@cloudcode.ai>"]
 license = "Apache2.0"


### PR DESCRIPTION
# Add API Base URL Configuration

- **Purpose:**
 Add support for configuring the API base URL for LiteLLM models in the Kaizen CLI.
- **Key Changes:**
  - Added a new `--api-base` option to the `add_model` command in `config_commands.py`.
  - Updated the `ConfigData` class in `config.py` to search for the configuration file in both the local directory and the user's home directory.
  - Bumped the version of the `kaizen-cli` package to `0.2.6`.
- **Impact:**
 This change allows users to specify the API base URL for their LiteLLM models, providing more flexibility in configuring the Kaizen CLI to work with different hosting environments.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>

</details>

